### PR TITLE
患者・オーダー・検査データの論理削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'bootsnap',     '1.4.4', require: false
 gem 'dotenv-rails', '2.7.2', require: 'dotenv/rails-now'
 gem 'httparty',     '0.17.0'
 gem 'paper_trail',  '10.3.1'
+gem 'discard',      '1.1.0'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
     crass (1.0.4)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
+    discard (1.1.0)
+      activerecord (>= 4.2, < 7)
     dotenv (2.7.2)
     dotenv-rails (2.7.2)
       dotenv (= 2.7.2)
@@ -250,6 +252,7 @@ DEPENDENCIES
   bullet
   capybara (>= 2.15)
   database_cleaner
+  discard (= 1.1.0)
   dotenv-rails (= 2.7.2)
   factory_bot_rails
   faker

--- a/REF.md
+++ b/REF.md
@@ -64,20 +64,13 @@
 - [render APIDock](https://apidock.com/rails/ActionController/Base/render)
 - [thoughtbot/shoulda-matchers: Simple one-liner tests for common Rails functionality](https://github.com/thoughtbot/shoulda-matchers)
 - [Built in matchers - RSpec Expectations - RSpec - Relish](https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers)
+- [How to assert resopnse body on RSpec](https://stackoverflow.com/questions/53613680/rspec-request-spec-examine-response-body)
 
 ## Ansible
 
 - [How do I exit Ansible playbook](https://stackoverflow.com/questions/36451793/how-do-i-exit-ansible-playbook-without-error-on-a-condition)
 - [Ansible command module says that "|" is illegal char](https://stackoverflow.com/questions/24679591/ansible-command-module-says-that-is-illegal-character#24685924)
 - [sed / awk / grep](https://qiita.com/shuntaro_tamura/items/e4e942e7186934fae5e7)
-
-## Capistrano
-
-- [Capistrano3でサブディレクトリをデプロイ - Qiita](https://qiita.com/akaryu0206/items/a4dbf56aca5cb31d141f)
-- [arsley/capistrano-deploy-test: Automate Rails project deploy test with capistrano, Circle CI](https://github.com/arsley/capistrano-deploy-test)
-- [Capistrano Variables - Freelancing Digest](https://www.freelancingdigest.com/articles/capistrano-variables/)
-- [ruby on rails - How to upload a file to release directory during Capistrano deploy? - Stack Overflow](https://stackoverflow.com/questions/53438458/how-to-upload-a-file-to-release-directory-during-capistrano-deploy)
-- [Set the Capistrano :deploy_to variable to the path "/var/www/" followed by the value of the :application variable. Use t | Treehouse Community](https://teamtreehouse.com/community/set-the-capistrano-deployto-variable-to-the-path-varwww-followed-by-the-value-of-the-application-variable-use-t-2)
 
 ## Other
 
@@ -90,3 +83,5 @@
 - [【エラー】Controller#Action is missing a template for this request format and variant.の解決法 - かしいさんのはじめて個人開発](https://blog.warally.info/entry/errors/missingtemplate)
 - [shields.io](https://shields.io/)
 - [GitHub の README.md をバッジでオシャレにできる Shields.io と dockeri.co](https://kakakakakku.hatenablog.com/entry/2018/08/08/200903)
+- [set CSRF token on axios](https://github.com/github/fetch/issues/424#issuecomment-259070410)
+- [How to redirect on JS](https://laracasts.com/discuss/channels/vue/how-to-redirect-to-another-page-after-submitting-the-form)

--- a/app/bundles/javascripts/controllers/components/delete_action_controller.js
+++ b/app/bundles/javascripts/controllers/components/delete_action_controller.js
@@ -1,0 +1,32 @@
+/* eslint no-console: 0 */
+
+import { Controller } from 'stimulus';
+import axios from 'axios';
+
+export default class extends Controller {
+  click(event) {
+    const csrf_token = document.querySelector('meta[name=csrf-token]').content;
+    const resource_path = this.data.get('resourcePath');
+    console.log(resource_path);
+
+    const agree = confirm('この作業は取り消せません。よろしいですか?');
+
+    if (agree) {
+      axios.delete(resource_path, {
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': csrf_token
+        }
+      })
+      .then(response => {
+        // redirect
+        window.location = response.data;
+      })
+      .catch(error => {
+        console.log(error);
+      });
+    } else {
+      event.preventDefault();
+    }
+  }
+}

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -44,6 +44,8 @@ class EmployeesController < ApplicationController
   def destroy
     employee = Employee.find_by(id: params[:id])
     employee.discard
+    reset_session
+    flash[:success] = '従業員データを削除しました。'
     render body: login_url, layout: false, status: :ok
   end
 

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -41,7 +41,11 @@ class EmployeesController < ApplicationController
     end
   end
 
-  def destroy; end
+  def destroy
+    employee = Employee.find_by(id: params[:id])
+    employee.discard
+    redirect_to employees_url
+  end
 
   private
 

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -44,7 +44,7 @@ class EmployeesController < ApplicationController
   def destroy
     employee = Employee.find_by(id: params[:id])
     employee.discard
-    redirect_to employees_url
+    render body: login_url, layout: false, status: :ok
   end
 
   private

--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -38,7 +38,7 @@ class InspectionsController < ApplicationController
   def destroy
     inspection = Inspection.find_by(id: params[:id])
     inspection.discard
-    redirect_to order_inspections_url(inspection.order.id)
+    render body: order_inspections_url(inspection.order.id), layout: false, status: :ok
   end
 
   private

--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -37,6 +37,7 @@ class InspectionsController < ApplicationController
 
   def destroy
     inspection = Inspection.find_by(id: params[:id])
+    inspection.paper_trail_event = 'discard'
     inspection.discard
     flash[:success] = '該当検査情報を削除しました。'
     render body: order_inspections_url(inspection.order.id), layout: false, status: :ok

--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -35,8 +35,11 @@ class InspectionsController < ApplicationController
     redirect_to order_inspections_url(@inspection.order)
   end
 
-  # 検査データは残します
-  def destroy; end
+  def destroy
+    inspection = Inspection.find_by(id: params[:id])
+    inspection.discard
+    redirect_to order_inspections_url(inspection.order.id)
+  end
 
   private
 

--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -38,6 +38,7 @@ class InspectionsController < ApplicationController
   def destroy
     inspection = Inspection.find_by(id: params[:id])
     inspection.discard
+    flash[:success] = '該当検査情報を削除しました。'
     render body: order_inspections_url(inspection.order.id), layout: false, status: :ok
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -34,8 +34,11 @@ class OrdersController < ApplicationController
     redirect_to patient_orders_path(@order.patient)
   end
 
-  # オーダーのデータは残します
-  def destroy; end
+  def destroy
+    order = Order.find_by(id: params[:id])
+    order.discard
+    redirect_to patient_orders_url(order.patient.id)
+  end
 
   private
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -37,7 +37,7 @@ class OrdersController < ApplicationController
   def destroy
     order = Order.find_by(id: params[:id])
     order.discard
-    redirect_to patient_orders_url(order.patient.id)
+    render body: patient_orders_url(order.patient.id), layout: false, status: :ok
   end
 
   private

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -37,6 +37,7 @@ class OrdersController < ApplicationController
   def destroy
     order = Order.find_by(id: params[:id])
     order.discard
+    flash[:success] = '該当オーダー情報を削除しました。'
     render body: patient_orders_url(order.patient.id), layout: false, status: :ok
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -36,6 +36,7 @@ class OrdersController < ApplicationController
 
   def destroy
     order = Order.find_by(id: params[:id])
+    order.paper_trail_event = 'discard'
     order.discard
     flash[:success] = '該当オーダー情報を削除しました。'
     render body: patient_orders_url(order.patient.id), layout: false, status: :ok

--- a/app/controllers/paper_trail/versions_controller.rb
+++ b/app/controllers/paper_trail/versions_controller.rb
@@ -1,6 +1,7 @@
 class PaperTrail::VersionsController < ApplicationController
   def index
-    @orders = rencent_histories(item_type: 'Order')
+    @patients    = rencent_histories(item_type: 'Patient', count: 5)
+    @orders      = rencent_histories(item_type: 'Order')
     @inspections = rencent_histories(item_type: 'Inspection')
   end
 
@@ -11,7 +12,7 @@ class PaperTrail::VersionsController < ApplicationController
 
   private
 
-  def rencent_histories(item_type:)
-    PaperTrail::Version.where(item_type: item_type).order(created_at: :desc).first(10)
+  def rencent_histories(item_type:, count: 10)
+    PaperTrail::Version.where(item_type: item_type).order(created_at: :desc).first(count)
   end
 end

--- a/app/controllers/paper_trail/versions_controller.rb
+++ b/app/controllers/paper_trail/versions_controller.rb
@@ -7,7 +7,7 @@ class PaperTrail::VersionsController < ApplicationController
 
   def show
     @history = PaperTrail::Version.find_by(id: params[:id])
-    @version_author = Employee.find_by(id: @history.version_author)
+    @version_author = Employee.with_discarded.find_by(id: @history.version_author)
   end
 
   private

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -39,6 +39,7 @@ class PatientsController < ApplicationController
 
   def destroy
     patient = Patient.find_by(id: params[:id])
+    patient.paper_trail_event = 'discard'
     patient.discard
     flash[:success] = '該当患者データを削除しました。'
     render body: patients_url, layout: false, status: :ok

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -40,6 +40,7 @@ class PatientsController < ApplicationController
   def destroy
     patient = Patient.find_by(id: params[:id])
     patient.discard
+    flash[:success] = '該当患者データを削除しました。'
     render body: patients_url, layout: false, status: :ok
   end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -37,7 +37,11 @@ class PatientsController < ApplicationController
     end
   end
 
-  def destroy; end
+  def destroy
+    patient = Patient.find_by(id: params[:id])
+    patient.discard
+    redirect_to patients_url
+  end
 
   private
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -40,7 +40,7 @@ class PatientsController < ApplicationController
   def destroy
     patient = Patient.find_by(id: params[:id])
     patient.discard
-    redirect_to patients_url
+    render body: patients_url, layout: false, status: :ok
   end
 
   private

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Employee < ApplicationRecord
+  # implement soft delete
+  include Discard::Model
+
   has_secure_password
 
   # validation

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -3,6 +3,7 @@
 class Employee < ApplicationRecord
   # implement soft delete
   include Discard::Model
+  default_scope -> { kept }
 
   has_secure_password
 

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -3,6 +3,7 @@
 class Inspection < ApplicationRecord
   # implement soft delete
   include Discard::Model
+  default_scope -> { kept }
 
   has_paper_trail
 

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Inspection < ApplicationRecord
+  # implement soft delete
+  include Discard::Model
+
   has_paper_trail
 
   # Define constant

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,6 +12,9 @@ class Order < ApplicationRecord
 
   # callbacks
   before_validation :set_default
+  after_discard do
+    inspections.update_all(discarded_at: discarded_at)
+  end
 
   # validations
   validates :canceled, inclusion: { in: [true, false] }

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,7 @@
 class Order < ApplicationRecord
   # implement soft delete
   include Discard::Model
+  default_scope -> { kept }
 
   has_paper_trail
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Order < ApplicationRecord
+  # implement soft delete
+  include Discard::Model
+
   has_paper_trail
 
   # constants

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -3,6 +3,7 @@
 class Patient < ApplicationRecord
   # implement soft delete
   include Discard::Model
+  default_scope -> { kept }
 
   # Define constant
   GENDERS = { 0 => '他', 1 => '男', 2 => '女' }.freeze

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -5,11 +5,17 @@ class Patient < ApplicationRecord
   include Discard::Model
   default_scope -> { kept }
 
+  has_paper_trail
+
   # Define constant
   GENDERS = { 0 => '他', 1 => '男', 2 => '女' }.freeze
 
   # Declare callback
   after_initialize :set_default
+  after_discard do
+    orders.each { |order| order.inspections.update_all(discarded_at: discarded_at) }
+    orders.update_all(discarded_at: discarded_at)
+  end
 
   # Declare validation
   validates :birth, :gender_id, :name, presence: true

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Patient < ApplicationRecord
+  # implement soft delete
+  include Discard::Model
+
   # Define constant
   GENDERS = { 0 => '他', 1 => '男', 2 => '女' }.freeze
 

--- a/app/views/ajax/inspections/edit.html.slim
+++ b/app/views/ajax/inspections/edit.html.slim
@@ -63,6 +63,12 @@
           p.control
             button.button.is-primary.has-text-weight-bold(type='submit' data-controller='components--submitbtn' data-action='components--submitbtn#click')
               | 更新
+            button.button.is-danger.has-text-weight-bold.is-pulled-right(
+              type='button'
+              data-controller='components--delete-action'
+              data-action='components--delete-action#click'
+              data-components--delete-action-resource-path="#{inspection_path(@inspection.id)}")
+              | 削除
             = link_to "検査リストへ戻る", order_inspections_path(@inspection.order), class: 'button is-text is-pulled-right'
 
   button.modal-close.is-large(aria-label='close' data-action='components--removebtn#click')

--- a/app/views/ajax/inspections/index.html.slim
+++ b/app/views/ajax/inspections/index.html.slim
@@ -1,10 +1,13 @@
 - @inspections.each do |inspection|
-  tr(class="#{inspection.urgent? ? 'has-text-white has-background-danger' : '' }")
+  tr(class="#{inspection.canceled? ? 'has-text-dark has-background-grey-light' : inspection.urgent? ? 'has-text-white has-background-danger' : '' }")
     td= inspection.formal_name
     td= inspection.status
     td= inspection.booked_at_to_s
     td= inspection.sample
     td= inspection.result
     td
-      a(class="#{inspection.urgent? ? 'has-text-warning' : ''}" data-controller='ajax--inspections' data-action='ajax--inspections#edit' data-ajax--inspections-edit-uri="#{edit_ajax_inspection_path(inspection.id)}")
+      a(class="#{inspection.canceled? ? '' : inspection.urgent? ? 'has-text-warning' : ''}"
+        data-controller='ajax--inspections'
+        data-action='ajax--inspections#edit'
+        data-ajax--inspections-edit-uri="#{edit_ajax_inspection_path(inspection.id)}")
         | 編集

--- a/app/views/ajax/orders/edit.html.slim
+++ b/app/views/ajax/orders/edit.html.slim
@@ -30,6 +30,12 @@
           p.control
             button.button.is-primary.has-text-weight-bold(type='submit' data-controller='components--submitbtn' data-action='components--submitbtn#click')
               | 更新
+            button.button.is-danger.has-text-weight-bold.is-pulled-right(
+              type='button'
+              data-controller='components--delete-action'
+              data-action='components--delete-action#click'
+              data-components--delete-action-resource-path="#{order_path(@order.id)}")
+              | 削除
             = link_to "オーダーリストへ戻る", patient_orders_path(@order.patient), class: 'button is-text is-pulled-right'
 
   button.modal-close.is-large(aria-label='close' data-action='components--removebtn#click')

--- a/app/views/ajax/orders/index.html.slim
+++ b/app/views/ajax/orders/index.html.slim
@@ -1,5 +1,5 @@
 - @orders.each do |order|
-  tr
+  tr(class="#{order.canceled? ? 'has-text-dark has-background-grey-light' : ''}")
     th= order.id
     td= link_to "オーダー##{order.id}", order_inspections_path(order.id)
     td= order.may_result_at_to_s

--- a/app/views/employees/edit.html.slim
+++ b/app/views/employees/edit.html.slim
@@ -43,3 +43,9 @@
             .control
               button.button.is-primary.has-text-weight-bold(type='submit' data-controller='components--submitbtn' data-action='components--submitbtn#click')
                 | 更新
+              button.button.is-danger.has-text-weight-bold.is-pulled-right(
+                type='button'
+                data-controller='components--delete-action'
+                data-action='components--delete-action#click'
+                data-components--delete-action-resource-path="#{employee_path(@employee.id)}")
+                | 削除

--- a/app/views/paper_trail/versions/index.html.slim
+++ b/app/views/paper_trail/versions/index.html.slim
@@ -4,6 +4,26 @@
   h1.title 更新履歴
 
 .section
+  h2.title.is-size-4 患者
+
+  table.table.is-hoverable
+    thead
+      tr
+        th 履歴ID
+        th 患者ID
+        th 操作
+        th 時刻
+        th 差分
+    tbody
+    - @patients.each do |patient|
+      tr
+        td= patient.id
+        td= patient.item_id
+        td= patient.event
+        td= patient.created_at.to_formatted_s(:abs_datetime)
+        td= link_to '詳細', history_path(patient.id)
+
+.section
   h2.title.is-size-4 オーダー
 
   table.table.is-hoverable

--- a/app/views/patients/edit.html.slim
+++ b/app/views/patients/edit.html.slim
@@ -40,3 +40,9 @@
             .control
               button.button.is-primary.has-text-weight-bold(type='submit' data-controller='components--submitbtn' data-action='components--submitbtn#click')
                 | 更新
+              button.button.is-danger.has-text-weight-bold.is-pulled-right(
+                type='button'
+                data-controller='components--delete-action'
+                data-action='components--delete-action#click'
+                data-components--delete-action-resource-path="#{patient_path(@patient.id)}")
+                | 削除

--- a/db/migrate/20190809045524_add_discarded_at_to_employees.rb
+++ b/db/migrate/20190809045524_add_discarded_at_to_employees.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToEmployees < ActiveRecord::Migration[5.2]
+  def change
+    add_column :employees, :discarded_at, :datetime
+    add_index :employees, :discarded_at
+  end
+end

--- a/db/migrate/20190809045609_add_discarded_at_to_patients.rb
+++ b/db/migrate/20190809045609_add_discarded_at_to_patients.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToPatients < ActiveRecord::Migration[5.2]
+  def change
+    add_column :patients, :discarded_at, :datetime
+    add_index :patients, :discarded_at
+  end
+end

--- a/db/migrate/20190809045628_add_discarded_at_to_orders.rb
+++ b/db/migrate/20190809045628_add_discarded_at_to_orders.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :discarded_at, :datetime
+    add_index :orders, :discarded_at
+  end
+end

--- a/db/migrate/20190809045647_add_discarded_at_to_inspections.rb
+++ b/db/migrate/20190809045647_add_discarded_at_to_inspections.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToInspections < ActiveRecord::Migration[5.2]
+  def change
+    add_column :inspections, :discarded_at, :datetime
+    add_index :inspections, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_03_093730) do
+ActiveRecord::Schema.define(version: 2019_08_09_045647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,8 @@ ActiveRecord::Schema.define(version: 2019_08_03_093730) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_employees_on_discarded_at"
   end
 
   create_table "inspection_details", force: :cascade do |t|
@@ -54,6 +56,8 @@ ActiveRecord::Schema.define(version: 2019_08_03_093730) do
     t.string "sample"
     t.string "result"
     t.datetime "booked_at"
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_inspections_on_discarded_at"
     t.index ["inspection_detail_id"], name: "index_inspections_on_inspection_detail_id"
     t.index ["order_id"], name: "index_inspections_on_order_id"
   end
@@ -65,6 +69,8 @@ ActiveRecord::Schema.define(version: 2019_08_03_093730) do
     t.bigint "patient_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_orders_on_discarded_at"
     t.index ["patient_id"], name: "index_orders_on_patient_id"
   end
 
@@ -74,6 +80,8 @@ ActiveRecord::Schema.define(version: 2019_08_03_093730) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_patients_on_discarded_at"
   end
 
   create_table "versions", force: :cascade do |t|

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,7 +14,7 @@ services:
     restart: always
 
   web:
-    image: czcdev/orderingsystem:0.2.0
+    image: czcdev/orderingsystem:0.3.0
     stdin_open: true
     tty: true
     links:

--- a/spec/requests/employees_spec.rb
+++ b/spec/requests/employees_spec.rb
@@ -158,6 +158,10 @@ RSpec.describe 'Employees', type: :request, js: true do
       expect(Employee.find_by(id: employee.id)).to be_nil
     end
 
+    it 'should remove current session' do
+      expect(session[:current_employee_id]).to be_nil
+    end
+
     it 'returns status code 200 OK' do
       expect(response).to have_http_status(200)
     end

--- a/spec/requests/employees_spec.rb
+++ b/spec/requests/employees_spec.rb
@@ -157,5 +157,7 @@ RSpec.describe 'Employees', type: :request, js: true do
     it 'cannot find by any resource because default_scope is set' do
       expect(Employee.find_by(id: employee.id)).to be_nil
     end
+
+    it { should redirect_to(employees_path) }
   end
 end

--- a/spec/requests/employees_spec.rb
+++ b/spec/requests/employees_spec.rb
@@ -151,13 +151,13 @@ RSpec.describe 'Employees', type: :request, js: true do
     before { delete employee_path(employee.id) }
 
     it 'deletes(discards) employee' do
-      expect(employee.discarded?).to be_truthy
+      expect(Employee.with_discarded.find_by(id: employee.id).discarded?).to be_truthy
     end
 
     it 'cannot find by any resource because default_scope is set' do
       expect(Employee.find_by(id: employee.id)).to be_nil
     end
 
-    it { should redirect_to(employees_path) }
+    it { should redirect_to(employees_url) }
   end
 end

--- a/spec/requests/employees_spec.rb
+++ b/spec/requests/employees_spec.rb
@@ -158,6 +158,12 @@ RSpec.describe 'Employees', type: :request, js: true do
       expect(Employee.find_by(id: employee.id)).to be_nil
     end
 
-    it { should redirect_to(employees_url) }
+    it 'returns status code 200 OK' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'should show redirect location on body' do
+      expect(response.body).to include(login_url)
+    end
   end
 end

--- a/spec/requests/employees_spec.rb
+++ b/spec/requests/employees_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe 'Employees', type: :request, js: true do
   end
 
   describe 'DELETE /employees/:id' do
-    pending 'data should not destroy'
+    before { delete employee_path(employee.id) }
+
+    it 'deletes(discards) employee' do
+      expect(employee.discarded?).to be_truthy
+    end
+
+    it 'cannot find by any resource because default_scope is set' do
+      expect(Employee.find_by(id: employee.id)).to be_nil
+    end
   end
 end

--- a/spec/requests/inspections_spec.rb
+++ b/spec/requests/inspections_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'Inspections', type: :request, js: true do
         expect(i.booked_at).to eq(valid_params[:inspection][:booked_at])
       end
 
-      it { should redirect_to(order_inspections_url(patient.id)) }
+      it { should redirect_to(order_inspections_url(inspection.order.id)) }
     end
   end
 
@@ -109,5 +109,7 @@ RSpec.describe 'Inspections', type: :request, js: true do
     it 'cannot find by any resource because default_scope is set' do
       expect(Inspection.find_by(id: inspection.id)).to be_nil
     end
+
+    it { should redirect_to(order_inspections_url(inspection.order.id)) }
   end
 end

--- a/spec/requests/inspections_spec.rb
+++ b/spec/requests/inspections_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Inspections', type: :request, js: true do
 
       before { put inspection_path(inspection.id), params: valid_params }
 
-      it 'updates inspetion' do
+      it 'updates inspection' do
         i = Inspection.find(inspection.id)
         expect(i.canceled?).to eq(valid_params[:inspection][:canceled])
         expect(i.urgent?).to   eq(valid_params[:inspection][:urgent])
@@ -100,6 +100,14 @@ RSpec.describe 'Inspections', type: :request, js: true do
   end
 
   describe 'DELETE /inspections/:id' do
-    pending 'data should not destroy'
+    before { delete inspection_path(inspection.id) }
+
+    it 'deletes(discards) inspection' do
+      expect(inspection.discarded?).to be_truthy
+    end
+
+    it 'cannot find by any resource because default_scope is set' do
+      expect(Inspection.find_by(id: inspection.id)).to be_nil
+    end
   end
 end

--- a/spec/requests/inspections_spec.rb
+++ b/spec/requests/inspections_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Inspections', type: :request, js: true do
     before { delete inspection_path(inspection.id) }
 
     it 'deletes(discards) inspection' do
-      expect(inspection.discarded?).to be_truthy
+      expect(Inspection.with_discarded.find_by(id: inspection.id).discarded?).to be_truthy
     end
 
     it 'cannot find by any resource because default_scope is set' do

--- a/spec/requests/inspections_spec.rb
+++ b/spec/requests/inspections_spec.rb
@@ -110,6 +110,12 @@ RSpec.describe 'Inspections', type: :request, js: true do
       expect(Inspection.find_by(id: inspection.id)).to be_nil
     end
 
-    it { should redirect_to(order_inspections_url(inspection.order.id)) }
+    it 'returns status code 200 OK' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'should show redirect location on body' do
+      expect(response.body).to include(order_inspections_url(inspection.order.id))
+    end
   end
 end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -116,6 +116,12 @@ RSpec.describe 'Orders', type: :request, js: true do
       expect(Order.find_by(id: order.id)).to be_nil
     end
 
-    it { should redirect_to(patient_orders_url(order.patient.id)) }
+    it 'returns status code 200 OK' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'should show redirect location on body' do
+      expect(response.body).to include(patient_orders_url(order.patient.id))
+    end
   end
 end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -100,6 +100,20 @@ RSpec.describe 'Orders', type: :request, js: true do
   end
 
   describe 'DELETE /orders/:id' do
-    pending 'data should not destroy'
+    before { delete order_path(order.id) }
+
+    it 'deletes(discards) order' do
+      expect(order.discarded?).to be_truthy
+    end
+
+    it 'also deletes(discards) releated inspections' do
+      order.inspections.each do |inspection|
+        expect(inspection.discarded?).to be_truthy
+      end
+    end
+
+    it 'cannot find by any resource because default_scope is set' do
+      expect(Order.find_by(id: order.id)).to be_nil
+    end
   end
 end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'Orders', type: :request, js: true do
         expect(Order.find(order.id).canceled?).to be_truthy
       end
 
-      it { should redirect_to(patient_orders_path(patient.id)) }
+      it { should redirect_to(patient_orders_path(order.patient.id)) }
     end
   end
 
@@ -115,5 +115,7 @@ RSpec.describe 'Orders', type: :request, js: true do
     it 'cannot find by any resource because default_scope is set' do
       expect(Order.find_by(id: order.id)).to be_nil
     end
+
+    it { should redirect_to(patient_orders_path(order.patient.id)) }
   end
 end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Orders', type: :request, js: true do
     before { delete order_path(order.id) }
 
     it 'deletes(discards) order' do
-      expect(order.discarded?).to be_truthy
+      expect(Order.with_discarded.find_by(id: order.id).discarded?).to be_truthy
     end
 
     it 'also deletes(discards) releated inspections' do
@@ -116,6 +116,6 @@ RSpec.describe 'Orders', type: :request, js: true do
       expect(Order.find_by(id: order.id)).to be_nil
     end
 
-    it { should redirect_to(patient_orders_path(order.patient.id)) }
+    it { should redirect_to(patient_orders_url(order.patient.id)) }
   end
 end

--- a/spec/requests/patients_spec.rb
+++ b/spec/requests/patients_spec.rb
@@ -164,6 +164,12 @@ RSpec.describe 'Patient', type: :request, js: true do
       end
     end
 
-    it { should redirect_to(patients_url) }
+    it 'returns status code 200 OK' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'should show redirect location on body' do
+      expect(response.body).to include(patients_url)
+    end
   end
 end

--- a/spec/requests/patients_spec.rb
+++ b/spec/requests/patients_spec.rb
@@ -163,5 +163,7 @@ RSpec.describe 'Patient', type: :request, js: true do
     it 'cannot find by any resource because default_scope i set' do
       expect(Patient.find_by(id: patient_id)).to be_nil
     end
+
+    it { should redirect_to(patients_path) }
   end
 end

--- a/spec/requests/patients_spec.rb
+++ b/spec/requests/patients_spec.rb
@@ -140,10 +140,14 @@ RSpec.describe 'Patient', type: :request, js: true do
   end
 
   describe 'DELETE /patients/:id' do
-    before { delete patient_path(patient_id) }
+    before { delete patient_path(patient.id) }
 
     it 'deletes(discards) patient' do
-      expect(patient.discarded?).to be_truthy
+      expect(Patient.with_discarded.find_by(id: patient.id).discarded?).to be_truthy
+    end
+
+    it 'cannot find by any resource because default_scope i set' do
+      expect(Patient.find_by(id: patient.id)).to be_nil
     end
 
     it 'also deletes(discards) releated orders' do
@@ -160,10 +164,6 @@ RSpec.describe 'Patient', type: :request, js: true do
       end
     end
 
-    it 'cannot find by any resource because default_scope i set' do
-      expect(Patient.find_by(id: patient_id)).to be_nil
-    end
-
-    it { should redirect_to(patients_path) }
+    it { should redirect_to(patients_url) }
   end
 end

--- a/spec/requests/patients_spec.rb
+++ b/spec/requests/patients_spec.rb
@@ -140,6 +140,28 @@ RSpec.describe 'Patient', type: :request, js: true do
   end
 
   describe 'DELETE /patients/:id' do
-    pending 'data should not destroy'
+    before { delete patient_path(patient_id) }
+
+    it 'deletes(discards) patient' do
+      expect(patient.discarded?).to be_truthy
+    end
+
+    it 'also deletes(discards) releated orders' do
+      patient.orders.each do |order|
+        expect(order.discarded?).to be_truthy
+      end
+    end
+
+    it 'also deletes(discards) releated inspections' do
+      patient.orders.each do |order|
+        order.inspections.each do |inspection|
+          expect(inspection.discarded?).to be_truthy
+        end
+      end
+    end
+
+    it 'cannot find by any resource because default_scope i set' do
+      expect(Patient.find_by(id: patient_id)).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Closes #59 

## 概要

従業員・患者・オーダー・検査について論理削除(以下単に「削除」という)機能を追加しました。
詳細については以下の通りです。

**上述したデータ群について削除機能を `discard` gem により追加**

- `resource.discard` により削除が可能
- `default_scope` を設定
  - `Employee.find_by(...)` などとした時に、削除済みのものを検索しません

**入れ子構造の削除については `update_all` で対処**

- これにより `UPDATE` 一回のみで子要素の削除が可能
  - 現状、患者データについては N+1 回かかる
  - 全オーダー取得→各オーダーに紐づく子要素を削除→オーダー削除
- `update_all` は PaperTrail に記録もされないため非常に都合が良い

**編集画面に削除ボタンを配置**

- 従業員・患者は編集ページに表示
- オーダー・検査はモーダルに表示
- Stimulus の controller `delete_action_controller` を作成し、 `DELETE` リクエストは axios により送信
  - axios のオプションとして `maxRedirection` (最大リダイレクト数の制限) が設定できなかったため Rails の `redirect_to` を利用しない方向で実装
  1. 処理に成功 → HTTP 200 OK とし、 `response.body` に遷移させたい先の URL を返す
  2. Stimulus の方で `response.body` を読み取り `windlow.location` を書き換えることでリダイレクト

**その他**

- 変更履歴 `/histories` に「患者」の変更履歴一覧を表示
- 変更差分 `/histories/:id` にて担当した従業員が削除されていても正しく表示できるように対処
- 削除機能を追加したデータ群に対してテストを追加
- 削除時の PaperTrail における event は `discard` とするように変更

以上です。