### PR TITLE
多要素のためのページネーション

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,5 +71,4 @@ workflows:
           filters:
             branches:
               only: master
-            tags:
-              only: /^v.*/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2
 jobs:
   build:
-    machine:
-      docker_layer_caching: true
+    machine: true
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 jobs:
   build:
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'dotenv-rails', '~> 2.7', require: 'dotenv/rails-now'
 gem 'httparty',     '~> 0.17'
 gem 'paper_trail',  '~> 10.3'
 gem 'discard',      '~> 1.1'
+gem 'kaminari',     '~> 1.1'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,18 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.2.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -255,6 +267,7 @@ DEPENDENCIES
   faker
   gimei
   httparty (~> 0.17)
+  kaminari (~> 1.1)
   listen
   paper_trail (~> 10.3)
   pg (~> 1.1)

--- a/app/bundles/javascripts/controllers/ajax/exams_controller.js
+++ b/app/bundles/javascripts/controllers/ajax/exams_controller.js
@@ -5,9 +5,10 @@ export default class extends Controller {
   index(event) {
     const canceled = event.target.value;
     const order_id = this.data.get('orderId');
+    const page = this.data.get('page');
 
     axios.get('/ajax/exams', {
-        params: { order_id, canceled }
+        params: { order_id, canceled, page }
       })
       .then(response => response.data)
       .then(html => document.querySelector('#exams-listup').innerHTML = html);

--- a/app/bundles/javascripts/controllers/ajax/orders_controller.js
+++ b/app/bundles/javascripts/controllers/ajax/orders_controller.js
@@ -5,9 +5,10 @@ export default class extends Controller {
   index(event) {
     const canceled = event.target.value;
     const patient_id = this.data.get('patientId');
+    const page = this.data.get('page');
 
     axios.get('/ajax/orders', {
-        params: { patient_id, canceled }
+        params: { patient_id, canceled, page }
       })
       .then(response => response.data)
       .then(html => document.querySelector('#orders-listup').innerHTML = html);

--- a/app/controllers/ajax/exams_controller.rb
+++ b/app/controllers/ajax/exams_controller.rb
@@ -6,9 +6,9 @@ class Ajax::ExamsController < ApplicationController
 
     @exams =
       if params[:canceled].to_i.zero?
-        @order.exams_only_active
+        @order.exams_only_active.page(params[:page])
       else
-        @order.exams_with_detail
+        @order.exams_with_detail.page(params[:page])
       end
     render layout: false
   end

--- a/app/controllers/ajax/orders_controller.rb
+++ b/app/controllers/ajax/orders_controller.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 class Ajax::OrdersController < ApplicationController
   def index
     @patient = Patient.find_by(id: params[:patient_id])
 
     @orders =
       if params[:canceled].to_i.zero?
-        @patient.orders_only_active
+        @patient.orders_only_active.page(params[:page])
       else
-        @patient.orders
+        @patient.orders.page(params[:page])
       end
     render layout: false
   end

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -4,7 +4,7 @@ class EmployeesController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :no_employee
 
   def index
-    @employees = Employee.all
+    @employees = Employee.page(params[:page])
   end
 
   def show

--- a/app/controllers/exam_items_controller.rb
+++ b/app/controllers/exam_items_controller.rb
@@ -4,7 +4,7 @@ class ExamItemsController < ApplicationController
   before_action :set_exam_datas, only: %i[new create edit update]
 
   def index
-    @exam_items = ExamItem.all
+    @exam_items = ExamItem.page(params[:page])
   end
 
   def new

--- a/app/controllers/exam_sets_controller.rb
+++ b/app/controllers/exam_sets_controller.rb
@@ -4,7 +4,7 @@ class ExamSetsController < ApplicationController
   before_action :set_exam_datas, only: %i[new create edit update]
 
   def index
-    @exam_sets = ExamSet.all
+    @exam_sets = ExamSet.page(params[:page])
   end
 
   def new

--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -5,6 +5,7 @@ class ExamsController < ApplicationController
   before_action :set_for_new, only: %i[new create]
 
   def index
+    @page  = params[:page] || 1
     @exams = @order.exams_only_active.page(params[:page])
   end
 

--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -5,7 +5,7 @@ class ExamsController < ApplicationController
   before_action :set_for_new, only: %i[new create]
 
   def index
-    @exams = @order.exams_only_active
+    @exams = @order.exams_only_active.page(params[:page])
   end
 
   def new; end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,7 +5,7 @@ class OrdersController < ApplicationController
   before_action :set_for_new, only: %i[new create]
 
   def index
-    @orders = @patient.orders_only_active
+    @orders = @patient.orders_only_active.page(params[:page])
   end
 
   def new; end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,6 +5,7 @@ class OrdersController < ApplicationController
   before_action :set_for_new, only: %i[new create]
 
   def index
+    @page   = params[:page] || 1
     @orders = @patient.orders_only_active.page(params[:page])
   end
 
@@ -55,7 +56,7 @@ class OrdersController < ApplicationController
   # DRYに反するということ、記述量の増加という点からメソッドとしてまとめ、
   # 'before_action' にフックしています。
   def set_for_new
-    @order = @patient.orders.new
+    @order      = @patient.orders.new
     @exam_sets  = ExamSet.all
     @exam_items = ExamItem.all
   end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -4,7 +4,7 @@ class PatientsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :no_patient
 
   def index
-    @patients = Patient.all
+    @patients = Patient.page(params[:page])
   end
 
   def new

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -3,7 +3,7 @@
 class Employee < ApplicationRecord
   # implement soft delete
   include Discard::Model
-  default_scope -> { kept }
+  default_scope -> { kept.order(:id) }
 
   has_secure_password
 

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -3,7 +3,7 @@
 class Exam < ApplicationRecord
   # implement soft delete
   include Discard::Model
-  default_scope -> { kept }
+  default_scope -> { kept.order(:id) }
 
   has_paper_trail
 

--- a/app/models/exam_item.rb
+++ b/app/models/exam_item.rb
@@ -3,7 +3,7 @@
 class ExamItem < ApplicationRecord
   # implement soft delete
   include Discard::Model
-  default_scope -> { kept }
+  default_scope -> { kept.order(:id) }
 
   has_paper_trail
 

--- a/app/models/exam_set.rb
+++ b/app/models/exam_set.rb
@@ -3,7 +3,7 @@
 class ExamSet < ApplicationRecord
   # implement soft delete
   include Discard::Model
-  default_scope -> { kept }
+  default_scope -> { kept.order(:id) }
 
   has_paper_trail
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,7 +3,7 @@
 class Order < ApplicationRecord
   # implement soft delete
   include Discard::Model
-  default_scope -> { kept }
+  default_scope -> { kept.order(:id) }
 
   has_paper_trail
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -3,7 +3,7 @@
 class Patient < ApplicationRecord
   # implement soft delete
   include Discard::Model
-  default_scope -> { kept }
+  default_scope -> { kept.order(:id) }
 
   has_paper_trail
 

--- a/app/service/create_notification_service.rb
+++ b/app/service/create_notification_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateNotificationService
   include ServiceHelper
   include HTTParty
@@ -48,10 +50,10 @@ class CreateNotificationService
   def notification_data
     @notification_data ||=
       case notification_type
-      when :order_created      then notification_data_order_created
-      when :order_updated      then notification_data_order_updated
-      when :inspection_added   then notification_data_inspection_added
-      when :inspection_updated then notification_data_inspection_updated
+      when :order_created then notification_data_order_created
+      when :order_updated then notification_data_order_updated
+      when :exam_added    then notification_data_exam_added
+      when :exam_updated  then notification_data_exam_updated
       else raise UndefinedNotificationTypeError
       end
   end
@@ -76,20 +78,20 @@ class CreateNotificationService
     }
   end
 
-  def notification_data_inspection_added
+  def notification_data_exam_added
     {
       contents: {
-        'en' => "Added inspections to Order##{order.id}.",
+        'en' => "Added exams to Order##{order.id}.",
         'ja' => "オーダー##{order.id}に検査が追加されました。"
       },
       type: '検査の追加'
     }
   end
 
-  def notification_data_inspection_updated
+  def notification_data_exam_updated
     {
       contents: {
-        'en' => "Updated inspection of Order##{order.id}.",
+        'en' => "Updated exam of Order##{order.id}.",
         'ja' => "オーダー##{order.id}の検査が更新されました。"
       },
       type: '検査の更新'

--- a/app/views/employees/index.html.slim
+++ b/app/views/employees/index.html.slim
@@ -14,3 +14,6 @@
         tr
           th= employee.id
           td= link_to employee.fullname, employee_path(employee.id)
+
+.section
+  = paginate @employees, theme: 'bulma'

--- a/app/views/exam_items/index.html.slim
+++ b/app/views/exam_items/index.html.slim
@@ -17,3 +17,6 @@
           td= exam_item.formal_name
           td= exam_item.abbreviation
           td= link_to '編集', edit_exam_item_path(exam_item.id)
+
+.section
+  = paginate @exam_items, theme: 'bulma'

--- a/app/views/exam_sets/index.html.slim
+++ b/app/views/exam_sets/index.html.slim
@@ -15,3 +15,6 @@
         tr
           td= exam_set.set_name
           td= link_to '編集', edit_exam_set_path(exam_set.id)
+
+.section
+  = paginate @exam_sets, theme: 'bulma'

--- a/app/views/exams/index.html.slim
+++ b/app/views/exams/index.html.slim
@@ -22,7 +22,8 @@
             = select_tag 'canceled', options_for_select({'非表示' => 0, '表示' => 1}),
               'data-controller': 'ajax--exams',
               'data-action': 'ajax--exams#index',
-              'data-ajax--exams-order-id': @order.id
+              'data-ajax--exams-order-id': @order.id,
+              'data-ajax--exams-page': @page
 
 .section
   table.table.is-hoverable

--- a/app/views/exams/index.html.slim
+++ b/app/views/exams/index.html.slim
@@ -38,4 +38,7 @@
     tbody#exams-listup
       = render file: 'ajax/exams/index'
 
+.section
+  = paginate @exams, theme: 'bulma'
+
 .section#exam-edit-modal

--- a/app/views/kaminari/bulma/_gap.html.slim
+++ b/app/views/kaminari/bulma/_gap.html.slim
@@ -1,0 +1,9 @@
+/ Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.pagination-elipsis
+  == t('views.pagination.truncate').html_safe
+'

--- a/app/views/kaminari/bulma/_next_page.html.slim
+++ b/app/views/kaminari/bulma/_next_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Next" page
+  - available local variables
+    url          : url to the next page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.next.pagination-next
+  == link_to_unless current_page.last?, '次へ', url, rel: 'next', remote: remote
+'

--- a/app/views/kaminari/bulma/_page.html.slim
+++ b/app/views/kaminari/bulma/_page.html.slim
@@ -1,0 +1,11 @@
+/ Link showing page number
+  - available local variables
+    page         : a page object for "this" page
+    url          : url to this page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span class="pagination-link #{'is-current' if page.current?}"
+  == link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}
+'

--- a/app/views/kaminari/bulma/_paginator.html.slim
+++ b/app/views/kaminari/bulma/_paginator.html.slim
@@ -1,0 +1,18 @@
+/ The container tag
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+    paginator    : the paginator that renders the pagination tags inside
+
+== paginator.render do
+  nav.pagination.is-centered.is-rounded
+    == prev_page_tag unless current_page.first?
+    .pagination-list
+      - each_page do |page|
+        - if page.display_tag?
+          == page_tag page
+        - elsif !page.was_truncated?
+          == gap_tag
+    == next_page_tag unless current_page.last?

--- a/app/views/kaminari/bulma/_prev_page.html.slim
+++ b/app/views/kaminari/bulma/_prev_page.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Previous" page
+  - available local variables
+    url          : url to the previous page
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.pagination-previous
+  == link_to_unless current_page.first?, '前へ', url, rel: 'prev', remote: remote
+'

--- a/app/views/orders/index.html.slim
+++ b/app/views/orders/index.html.slim
@@ -30,4 +30,7 @@
     tbody#orders-listup
       = render file: 'ajax/orders/index'
 
+.section
+  = paginate @orders, theme: 'bulma'
+
 .section#order-edit-modal

--- a/app/views/orders/index.html.slim
+++ b/app/views/orders/index.html.slim
@@ -16,7 +16,10 @@
         .control
           .select
             = select_tag 'canceled', options_for_select({'非表示' => 0, '表示' => 1}),\
-              'data-controller': 'ajax--orders', 'data-action': 'ajax--orders#index', 'data-ajax--orders-patient-id': @patient.id
+              'data-controller': 'ajax--orders',
+              'data-action': 'ajax--orders#index',
+              'data-ajax--orders-patient-id': @patient.id,
+              'data-ajax--orders-page': @page
 
 .section
   table.table.is-hoverable

--- a/app/views/patients/index.html.slim
+++ b/app/views/patients/index.html.slim
@@ -14,3 +14,6 @@
         tr
           th= patient.id
           td= link_to patient.name, patient_orders_path(patient.id)
+
+.section
+  = paginate @patients, theme: 'bulma'

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # config.max_per_page = nil
+  config.window = 3
+  config.outer_window = 1
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,7 +14,7 @@ services:
     restart: always
 
   web:
-    image: czcdev/orderingsystem:0.5.1
+    image: czcdev/orderingsystem:0.6.0
     stdin_open: true
     tty: true
     links:

--- a/spec/requests/ajax/exams_spec.rb
+++ b/spec/requests/ajax/exams_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Ajax::Exams', type: :request, js: true do
@@ -8,6 +10,28 @@ RSpec.describe 'Ajax::Exams', type: :request, js: true do
 
   # 全てのアクションにおいてログインが必要です
   before { post login_path, params: { username: employee.username, password: employee.password } }
+
+  describe 'GET /ajax/exams/index' do
+    context 'when params: canceled specified' do
+      before { get ajax_exams_path, params: params }
+
+      let(:params) { { order_id: order.id, page: 1, canceled: 1 } }
+
+      it 'can show first page of exams with canceled' do
+        expect(assigns[:exams]).to eq(order.exams_with_detail.page(params[:page]))
+      end
+    end
+
+    context 'when params: canceled not specified' do
+      before { get ajax_exams_path, params: params }
+
+      let(:params) { { order_id: order.id, page: 1, canceled: 0 } }
+
+      it 'can show first page of exams without canceled' do
+        expect(assigns[:exams]).to eq(order.exams_only_active.page(params[:page]))
+      end
+    end
+  end
 
   describe 'GET /ajax/exams/edit/:id' do
     context 'when exam was created by machine(not employee)' do

--- a/spec/requests/ajax/orders_spec.rb
+++ b/spec/requests/ajax/orders_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Ajax::Orders', type: :request, js: true do
@@ -7,6 +9,28 @@ RSpec.describe 'Ajax::Orders', type: :request, js: true do
 
   # 全てのアクションにおいてログインが必要です
   before { post login_path, params: { username: employee.username, password: employee.password } }
+
+  describe 'GET /ajax/orders/index' do
+    context 'when params: canceled specified' do
+      before { get ajax_orders_path, params: params }
+
+      let(:params) { { patient_id: patient.id, page: 1, canceled: 1 } }
+
+      it 'can show first page of orders with canceled' do
+        expect(assigns[:orders]).to eq(patient.orders.page(params[:page]))
+      end
+    end
+
+    context 'when params: canceled not specified' do
+      before { get ajax_orders_path, params: params }
+
+      let(:params) { { patient_id: patient.id, page: 1, canceled: 0 } }
+
+      it 'can show first page of orders without canceled' do
+        expect(assigns[:orders]).to eq(patient.orders_only_active.page(params[:page]))
+      end
+    end
+  end
 
   describe 'GET /ajax/orders/edit/:id' do
     context 'when order was created by machine(not employee)' do

--- a/spec/requests/employees/index_spec.rb
+++ b/spec/requests/employees/index_spec.rb
@@ -8,13 +8,14 @@ RSpec.describe 'Employees GET /employees', type: :request, js: true do
   let!(:employees) { create_list(:employee, 5) }
   let(:employee) { employees.first }
   let(:employee_id) { employee.id }
+  let(:params) { { page: 1 } }
 
   # 全てのアクションにおいてログインが必要です
   before { post login_path, params: { username: administor.username, password: administor.password } }
 
-  before { get employees_path }
+  before { get employees_path, params: params }
 
-  it 'can show all employees' do
-    expect(Employee.all).to eq(assigns[:employees])
+  it 'can show all employees on first page' do
+    expect(assigns[:employees]).to eq(Employee.page(params[:page]))
   end
 end

--- a/spec/requests/exam_items/index_spec.rb
+++ b/spec/requests/exam_items/index_spec.rb
@@ -5,14 +5,15 @@ require 'rails_helper'
 RSpec.describe 'ExamItems GET /exam_items', type: :request, js: true do
   # WARNING: 稀に Faker::Internet.username で生成した擬似ユーザー名が衝突する場合があります
   let!(:administor) { create(:administor) }
+  let(:params) { { page: 1 } }
 
   # 全てのアクションにおいてログインが必要です
   before { post login_path, params: { username: administor.username, password: administor.password } }
 
-  before { get exam_items_path }
+  before { get exam_items_path, params: params }
 
-  it 'can show all exam_items' do
-    expect(assigns[:exam_items]).to eq(ExamItem.all)
+  it 'can show all exam_items on first page' do
+    expect(assigns[:exam_items]).to eq(ExamItem.page(params[:page]))
   end
 
   it { should render_template('index') }

--- a/spec/requests/exam_sets/index_spec.rb
+++ b/spec/requests/exam_sets/index_spec.rb
@@ -5,14 +5,15 @@ require 'rails_helper'
 RSpec.describe 'ExamSets GET /exam_sets', type: :request, js: true do
   # WARNING: 稀に Faker::Internet.username で生成した擬似ユーザー名が衝突する場合があります
   let!(:administor) { create(:administor) }
+  let(:params) { { page: 1 } }
 
   # 全てのアクションにおいてログインが必要です
   before { post login_path, params: { username: administor.username, password: administor.password } }
 
   before { get exam_sets_path }
 
-  it 'can show all exam sets' do
-    expect(assigns[:exam_sets]).to eq(ExamSet.all)
+  it 'can show all exam sets on first page' do
+    expect(assigns[:exam_sets]).to eq(ExamSet.page(params[:page]))
   end
 
   it { should render_template('index') }

--- a/spec/requests/exams/index_spec.rb
+++ b/spec/requests/exams/index_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe 'Exams GET /orders/:order_id/exams', type: :request, js: true do
     expect(assigns[:exams]).to eq(order.exams_only_active.page(params[:page]))
   end
 
+  it 'should use variable "page" for making ajax request' do
+    expect(assigns[:page]).to eq(params[:page])
+  end
+
   it 'returns status code 200' do
     expect(response).to have_http_status(200)
   end

--- a/spec/requests/exams/index_spec.rb
+++ b/spec/requests/exams/index_spec.rb
@@ -7,14 +7,15 @@ RSpec.describe 'Exams GET /orders/:order_id/exams', type: :request, js: true do
   let(:patient) { create(:patient) }
   let(:order) { patient.orders.first }
   let(:exam) { order.exams.first }
+  let(:params) { { page: 1 } }
 
   # 全てのアクションにおいてログインが必要です
   before { post login_path, params: { username: employee.username, password: employee.password } }
 
   before { get order_exams_path(order.id) }
 
-  it "can show order's exams exclude canceled one" do
-    expect(assigns[:exams]).to eq(order.exams_only_active)
+  it "can show order's exams exclude canceled one on first page" do
+    expect(assigns[:exams]).to eq(order.exams_only_active.page(params[:page]))
   end
 
   it 'returns status code 200' do

--- a/spec/requests/orders/index_spec.rb
+++ b/spec/requests/orders/index_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'Orders GET /patients/:patient_id/orders', type: :request, js: tr
     expect(assigns[:orders]).to eq(patient.orders_only_active.page(params[:page]))
   end
 
+  it 'should use variable "page" for making ajax request' do
+    expect(assigns[:page]).to eq(params[:page])
+  end
+
   it 'returns status code 200' do
     expect(response).to have_http_status(200)
   end

--- a/spec/requests/orders/index_spec.rb
+++ b/spec/requests/orders/index_spec.rb
@@ -8,14 +8,15 @@ RSpec.describe 'Orders GET /patients/:patient_id/orders', type: :request, js: tr
   let(:patient) { create(:patient) }
   let(:order) { patient.orders.first }
   let(:employee) { create(:employee) }
+  let(:params) { { page: 1 } }
 
   # 全てのアクションにおいてログインが必要です
   before { post login_path, params: { username: employee.username, password: employee.password } }
 
   before { get "/patients/#{patient.id}/orders" }
 
-  it "can show patient's orders exclude canceled one" do
-    expect(assigns[:orders]).to eq(patient.orders_only_active)
+  it "can show patient's orders exclude canceled one on first page" do
+    expect(assigns[:orders]).to eq(patient.orders_only_active.page(params[:page]))
   end
 
   it 'returns status code 200' do

--- a/spec/requests/patients/index_spec.rb
+++ b/spec/requests/patients/index_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Patient GET /patients', type: :request, js: true do
   let(:patient) { patients.first }
   let(:patient_id) { patient.id }
   let(:employee) { create(:employee) }
+  let(:params) { { page: 1 } }
 
   # 全てのアクションにおいてログインが必要です
   before { post login_path, params: { username: employee.username, password: employee.password } }
@@ -14,7 +15,7 @@ RSpec.describe 'Patient GET /patients', type: :request, js: true do
   before { get '/patients' }
 
   it 'can show all patient' do
-    expect(Patient.all).to eq(assigns[:patients])
+    expect(assigns[:patients]).to eq(Patient.page(params[:page]))
   end
 
   it 'returns status code 200' do


### PR DESCRIPTION
Resolve #68

## 概要

各種一覧表示ページにて、表示したいリソースの数が多いと見辛くなるためページネーションを導入しました。

**`gem kaminari` のデフォルトテーマを一部改変して利用**

- `app/views/kaminari/bulma` 以下に各種Viewを配置
- Bulma のスタイルを適用するように調節
- 表示数などの詳細もデフォルトから一部改変
  - 単一ページにおける各要素の最大表示数は 20
  - 隣接しているページの表示数は 3
  - 両端の表示数は 1

**テーブルに一覧表示をする形のリソース全てにページネーションを導入**

- `Resource.all` ではなく `Resource.page(params[:page])` によりデータを取得
- 各種 index ページにおけるテストも修正

**キャンセル済みの表示・非表示を行うオーダーおよび検査一覧ページの JS 周りを修正**

- View から `page` 変数を通じて Stimulus Controller においても現在のページ数を参照可能に
  - 表示ページが何ページ目かを ajax Request においても渡す必要があるため
- 該当内容の index テストも追加

## その他

**リソースの並び順が一意になるよう `default_scope` を変更**

- `Resource.all` だと更新時刻降順になってしまったものを、DBのID昇順になるよう変更
  - 今回ページネーションを追加したリソース全てを変更対象とした

**`CreateNotificationService` にて `UndefinedNotificationType` が発生したため修正**

- #70 にて行ったモデル名変更に際して修正をし損ねていた箇所
  - Controller 側では `notification_type: :exam_create` などと改名されていたものの、呼び出し先の方では該当 Type 名に変更がなされていなかった

以上です。